### PR TITLE
Give definition for base entity in catalog.bom

### DIFF
--- a/catalog/spark/spark.bom
+++ b/catalog/spark/spark.bom
@@ -9,10 +9,22 @@ brooklyn.catalog:
     overview: README.md
     reference: catalog/reference.json
   items:
+  - id: spark-base-software-process
+    name: "Spark Base Software Process"
+    description: |
+      A base entity for reuse in other components.
+    itemType: entity
+    item:
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      brooklyn.config:
+        dontRequireTtyForSudo: true
+        provisioning.properties:
+          osFamily: centos
+          osVersionRegex: 7
   - id: spark-node
     description: A standalone Apache Spark node, master unless given a spark.master.url
     item:
-      type: centos7-software-process
+      type: spark-base-software-process
       name: Apache Spark Standalone Node
       brooklyn.parameters:
       - &sparkDownloadUrl


### PR DESCRIPTION
Removes the implicit dependency on the Clocker project.

As it stands the blueprints in catalog.bom cannot be added to a vanilla Brooklyn server.